### PR TITLE
additional checks for potential errors while uploading image to cloudinary added

### DIFF
--- a/07-file-upload/final/controllers/uploadsController.js
+++ b/07-file-upload/final/controllers/uploadsController.js
@@ -27,6 +27,20 @@ const uploadProductImageLocal = async (req, res) => {
 };
 
 const uploadProductImage = async (req, res) => {
+
+  //additional checks for proper image uploading and error handling
+  if (!req.files) {
+    throw new CustomError.BadRequestError('No File Uploaded');
+  }
+  const productImage = req.files.image;
+  if (!productImage.mimetype.startsWith('image')) {
+    throw new CustomError.BadRequestError('Please Upload Image');
+  }
+  const maxSize = 1024 * 1024;
+  if (productImage.size > maxSize) {
+    throw new CustomError.BadRequestError('Please upload image smaller then 1MB');
+  }
+
   const result = await cloudinary.uploader.upload(
     req.files.image.tempFilePath,
     {


### PR DESCRIPTION
In the [uploadsController.js](https://github.com/ankushgupta365/node-express-course/blob/main/07-file-upload/final/controllers/uploadsController.js) file of [07-file-upload](https://github.com/ankushgupta365/node-express-course/tree/main/07-file-upload) project, the controller which is handling the request to add the image file to Cloudinary was not clearly handling the errors and edge cases which may occur when :-
1. we did not provide the file and call the endpoint
2. we provide file other than the mimetype of image
3. we provide very large file size, greater than 1MB

So, to handle this I have added some additional code to uploadProductImage controller which is present at line 29 of this [file](https://github.com/ankushgupta365/node-express-course/blob/main/07-file-upload/final/controllers/uploadsController.js), screenshot for that code is added below :-


![Screenshot (41)](https://user-images.githubusercontent.com/86787266/191793158-4815f236-5268-4a2c-b807-68978ce7bd18.png)

Now, all the edge cases will going to be handled nicely!

