### PR TITLE
Allow range operator for price field

### DIFF
--- a/04-store-api/final/controllers/products.js
+++ b/04-store-api/final/controllers/products.js
@@ -37,6 +37,10 @@ const getAllProducts = async (req, res) => {
     filters = filters.split(',').forEach((item) => {
       const [field, operator, value] = item.split('-');
       if (options.includes(field)) {
+        if (queryObject[field]) {
+          queryObject[field][operator] = Number(value);
+          return;
+        }
         queryObject[field] = { [operator]: Number(value) };
       }
     });


### PR DESCRIPTION
## If the query string contains range boundaries, i.e. ` price>15,price<20`, the latter predicate will overwrite the former one.



In this update, another check is made to ensure that the field wasn't added before, if not (the field already exists), it adds the operator and its value to the field object.

```
...
...
if (queryObject[field]) {
  queryObject[field][operator] = Number(value);
  return;
}
queryObject[field] = { [operator]: Number(value) };
...
...
````
``